### PR TITLE
Implement Paging 3 for Events List

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,10 @@ android {
 }
 
 dependencies {
+    //Paging
+    implementation(libs.androidx.paging.runtime)
+    implementation (libs.androidx.paging.compose)
+
     //Navigation
     implementation(libs.androidx.navigation.compose)
 

--- a/app/src/main/java/denys/diomaxius/nzevents/data/remote/api/EventsFindApi.kt
+++ b/app/src/main/java/denys/diomaxius/nzevents/data/remote/api/EventsFindApi.kt
@@ -7,16 +7,19 @@ import retrofit2.http.Query
 interface EventsFindApi  {
     @GET("events.json")
     suspend fun getEvents(
-        @Query("rows") rows: Int
+        @Query("rows") rows: Int = 10,
+        @Query("offset") offset: Int = 0
+    ): EventsResponseDto
+
+    @GET("events.json")
+    suspend fun getEventsByLocation(
+        @Query("location") location: Int,
+        @Query("rows") rows: Int = 10,
+        @Query("offset") offset: Int = 0
     ): EventsResponseDto
 
     @GET("events.json")
     suspend fun getEvent(
         @Query("id") id: String
-    ): EventsResponseDto
-
-    @GET("events.json")
-    suspend fun getEventsByLocation(
-        @Query("location") location: Int
     ): EventsResponseDto
 }

--- a/app/src/main/java/denys/diomaxius/nzevents/data/remote/dto/EventDto.kt
+++ b/app/src/main/java/denys/diomaxius/nzevents/data/remote/dto/EventDto.kt
@@ -4,7 +4,14 @@ import com.google.gson.annotations.SerializedName
 
 
 data class EventsResponseDto(
+    @SerializedName("@attributes")
+    val attributes: AttributesDto,
     val events: List<EventDto>
+)
+
+data class AttributesDto(
+    @SerializedName("count")
+    val count: Int
 )
 
 data class EventDto(

--- a/app/src/main/java/denys/diomaxius/nzevents/data/remote/mapper/EventMapper.kt
+++ b/app/src/main/java/denys/diomaxius/nzevents/data/remote/mapper/EventMapper.kt
@@ -10,6 +10,7 @@ import denys.diomaxius.nzevents.domain.model.Session
 import denys.diomaxius.nzevents.domain.model.SessionsWrapper
 
 fun EventsResponseDto.toDomain(): Events = Events(
+    count = this.attributes.count,
     events = this.events.map { it.toDomain() }
 )
 

--- a/app/src/main/java/denys/diomaxius/nzevents/data/remote/network/RetrofitInstance.kt
+++ b/app/src/main/java/denys/diomaxius/nzevents/data/remote/network/RetrofitInstance.kt
@@ -6,6 +6,7 @@ import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 
 object RetrofitInstance {
     private const val BASE_URL = "https://api.eventfinda.co.nz/v2/"
@@ -19,6 +20,8 @@ object RetrofitInstance {
                 .build()
             chain.proceed(request)
         }
+        .connectTimeout(60, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
         .build()
 
     val api: EventsFindApi by lazy {

--- a/app/src/main/java/denys/diomaxius/nzevents/data/remote/paging/EventsPagingSource.kt
+++ b/app/src/main/java/denys/diomaxius/nzevents/data/remote/paging/EventsPagingSource.kt
@@ -1,0 +1,51 @@
+package denys.diomaxius.nzevents.data.remote.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import denys.diomaxius.nzevents.data.remote.api.EventsFindApi
+import denys.diomaxius.nzevents.data.remote.mapper.toDomain
+import denys.diomaxius.nzevents.domain.model.Event
+
+class EventsPagingSource(
+    private val api: EventsFindApi,
+    private val locationId: Int? = null,
+    private val pageSize: Int = 100
+) : PagingSource<Int, Event>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Event> {
+        return try {
+            val offset = params.key ?: 0
+
+            val response = if (locationId == null) {
+                api.getEvents(rows = pageSize, offset = offset)
+            } else {
+                api.getEventsByLocation(location = locationId, rows = pageSize, offset = offset)
+            }
+
+            val items: List<Event> = response.events.map { dto ->
+                dto.toDomain()
+            }
+
+            val nextOffset = if (items.isEmpty() || offset + items.size >= response.attributes.count) {
+                null
+            } else {
+                offset + items.size
+            }
+
+            LoadResult.Page(
+                data = items,
+                prevKey = null,
+                nextKey = nextOffset
+            )
+        } catch (ex: Exception) {
+            LoadResult.Error(ex)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, Event>): Int? {
+        return state.anchorPosition?.let { anchor ->
+            val page = state.closestPageToPosition(anchor)
+            page?.prevKey ?: page?.nextKey?.minus(pageSize)
+        }
+    }
+}

--- a/app/src/main/java/denys/diomaxius/nzevents/data/repository/EventsRepositoryImpl.kt
+++ b/app/src/main/java/denys/diomaxius/nzevents/data/repository/EventsRepositoryImpl.kt
@@ -1,10 +1,15 @@
 package denys.diomaxius.nzevents.data.repository
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
 import denys.diomaxius.nzevents.data.remote.mapper.toDomain
 import denys.diomaxius.nzevents.data.remote.api.EventsFindApi
+import denys.diomaxius.nzevents.data.remote.paging.EventsPagingSource
 import denys.diomaxius.nzevents.domain.model.Event
 import denys.diomaxius.nzevents.domain.model.Events
 import denys.diomaxius.nzevents.domain.repository.EventsRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class EventsRepositoryImpl @Inject constructor(
@@ -23,5 +28,37 @@ class EventsRepositoryImpl @Inject constructor(
     override suspend fun getEventsByLocation(location: Int): Events {
         val response = api.getEventsByLocation(location)
         return response.toDomain()
+    }
+
+    override fun getEventsPager(pageSize: Int): Flow<PagingData<Event>> {
+        return Pager(
+            config = PagingConfig(
+                pageSize = pageSize,
+                enablePlaceholders = false
+            ),
+            pagingSourceFactory = {
+                EventsPagingSource(
+                    api = api,
+                    locationId = null,
+                    pageSize = pageSize
+                )
+            }
+        ).flow
+    }
+
+    override fun getEventsByLocationPager(location: Int, pageSize: Int): Flow<PagingData<Event>> {
+        return Pager(
+            config = PagingConfig(
+                pageSize = pageSize,
+                enablePlaceholders = false
+            ),
+            pagingSourceFactory = {
+                EventsPagingSource(
+                    api = api,
+                    locationId = location,
+                    pageSize = pageSize
+                )
+            }
+        ).flow
     }
 }

--- a/app/src/main/java/denys/diomaxius/nzevents/domain/model/Events.kt
+++ b/app/src/main/java/denys/diomaxius/nzevents/domain/model/Events.kt
@@ -1,5 +1,6 @@
 package denys.diomaxius.nzevents.domain.model
 
 data class Events(
+    val count: Int,
     val events: List<Event>
 )

--- a/app/src/main/java/denys/diomaxius/nzevents/domain/repository/EventsRepository.kt
+++ b/app/src/main/java/denys/diomaxius/nzevents/domain/repository/EventsRepository.kt
@@ -1,10 +1,16 @@
 package denys.diomaxius.nzevents.domain.repository
 
+import androidx.paging.PagingData
 import denys.diomaxius.nzevents.domain.model.Event
 import denys.diomaxius.nzevents.domain.model.Events
+import kotlinx.coroutines.flow.Flow
 
 interface EventsRepository {
     suspend fun getEvents(rows: Int): Events
     suspend fun getEvent(id: String): Event
     suspend fun getEventsByLocation(location: Int): Events
+
+    //Paging 3
+    fun getEventsPager(pageSize: Int = 100): Flow<PagingData<Event>>
+    fun getEventsByLocationPager(location: Int, pageSize: Int = 100): Flow<PagingData<Event>>
 }

--- a/app/src/main/java/denys/diomaxius/nzevents/domain/usecase/GetEventsByLocationPagerUseCase.kt
+++ b/app/src/main/java/denys/diomaxius/nzevents/domain/usecase/GetEventsByLocationPagerUseCase.kt
@@ -1,0 +1,15 @@
+package denys.diomaxius.nzevents.domain.usecase
+
+import androidx.paging.PagingData
+import denys.diomaxius.nzevents.domain.model.Event
+import denys.diomaxius.nzevents.domain.repository.EventsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetEventsByLocationPagerUseCase @Inject constructor(
+    private val repository: EventsRepository
+) {
+    operator fun invoke(location: Int, pageSize: Int = 100): Flow<PagingData<Event>> {
+        return repository.getEventsByLocationPager(location, pageSize)
+    }
+}

--- a/app/src/main/java/denys/diomaxius/nzevents/domain/usecase/GetEventsPagerUseCase.kt
+++ b/app/src/main/java/denys/diomaxius/nzevents/domain/usecase/GetEventsPagerUseCase.kt
@@ -1,0 +1,15 @@
+package denys.diomaxius.nzevents.domain.usecase
+
+import androidx.paging.PagingData
+import denys.diomaxius.nzevents.domain.model.Event
+import denys.diomaxius.nzevents.domain.repository.EventsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetEventsPagerUseCase @Inject constructor(
+    private val repository: EventsRepository
+) {
+    operator fun invoke(pageSize: Int = 100): Flow<PagingData<Event>> {
+        return repository.getEventsPager(pageSize)
+    }
+}

--- a/app/src/main/java/denys/diomaxius/nzevents/ui/screen/home/HomeContent.kt
+++ b/app/src/main/java/denys/diomaxius/nzevents/ui/screen/home/HomeContent.kt
@@ -1,21 +1,27 @@
 package denys.diomaxius.nzevents.ui.screen.home
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
 import denys.diomaxius.nzevents.domain.model.Event
 import denys.diomaxius.nzevents.navigation.Screen
 
 @Composable
 fun Content(
     modifier: Modifier,
-    events: List<Event>,
+    pagingItems: LazyPagingItems<Event>,
     navHostController: NavHostController
 ) {
     Column(
@@ -24,15 +30,72 @@ fun Content(
             .padding(horizontal = 16.dp)
     ) {
         LazyColumn {
-            items(events) { event ->
-                EventItemCard(
-                    event = event,
-                    onItemClick = {
-                        navHostController.navigate(Screen.Event.createRoute(event.id)) {
-                            launchSingleTop = true
-                        }
+            if (pagingItems.loadState.refresh is LoadState.Loading) {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 16.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text("Loading...", modifier = Modifier.align(Alignment.Center))
                     }
-                )
+                }
+            }
+
+            items(count = pagingItems.itemCount) { index ->
+                val event = pagingItems[index]
+                event?.let {
+                    EventItemCard(
+                        event = it,
+                        onItemClick = {
+                            navHostController.navigate(
+                                Screen.Event.createRoute(it.id)
+                            ) {
+                                launchSingleTop = true
+                            }
+                        }
+                    )
+                }
+            }
+
+            if (pagingItems.loadState.append is LoadState.Loading) {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 16.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+            }
+
+            if (pagingItems.loadState.refresh is LoadState.Error) {
+                val e = pagingItems.loadState.refresh as LoadState.Error
+                item {
+                    Text(
+                        "Error Loading: ${e.error.localizedMessage}",
+                        color = androidx.compose.ui.graphics.Color.Red,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp)
+                    )
+                }
+            }
+
+            if (pagingItems.loadState.append is LoadState.Error) {
+                val e = pagingItems.loadState.append as LoadState.Error
+                item {
+                    Text(
+                        "Error load more: ${e.error.localizedMessage}",
+                        color = androidx.compose.ui.graphics.Color.Red,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp)
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/denys/diomaxius/nzevents/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/denys/diomaxius/nzevents/ui/screen/home/HomeScreen.kt
@@ -6,18 +6,17 @@ import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.paging.compose.collectAsLazyPagingItems
 import denys.diomaxius.nzevents.navigation.LocalNavController
 
 @Composable
 fun HomeScreen(
     viewModel: HomeScreenViewModel = hiltViewModel()
 ) {
-    val events by viewModel.events.collectAsState()
+    val lazyPagingItems = viewModel.eventsPager.collectAsLazyPagingItems()
     val navHostController = LocalNavController.current
 
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
@@ -26,7 +25,7 @@ fun HomeScreen(
     ModalNavigationDrawer(
         drawerContent = {
             HomeDrawerContent(
-                changeLocation = { viewModel.getEventsByLocation(it) },
+                changeLocation = { viewModel.setLocationFilter(it) },
                 resetLocationFilter = { viewModel.resetLocationFilter() }
             )
         },
@@ -42,8 +41,8 @@ fun HomeScreen(
         ) { innerPadding ->
             Content(
                 modifier = Modifier.padding(innerPadding),
-                events = events,
-                navHostController = navHostController
+                navHostController = navHostController,
+                pagingItems = lazyPagingItems
             )
         }
     }

--- a/app/src/main/java/denys/diomaxius/nzevents/ui/screen/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/denys/diomaxius/nzevents/ui/screen/home/HomeScreenViewModel.kt
@@ -3,49 +3,48 @@ package denys.diomaxius.nzevents.ui.screen.home
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import dagger.hilt.android.lifecycle.HiltViewModel
 import denys.diomaxius.nzevents.domain.model.Event
+import denys.diomaxius.nzevents.domain.usecase.GetEventsByLocationPagerUseCase
 import denys.diomaxius.nzevents.domain.usecase.GetEventsByLocationUseCase
+import denys.diomaxius.nzevents.domain.usecase.GetEventsPagerUseCase
 import denys.diomaxius.nzevents.domain.usecase.GetEventsUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeScreenViewModel @Inject constructor(
-    private val getEventsUseCase: GetEventsUseCase,
-    private val getEventsByLocationUseCase: GetEventsByLocationUseCase
+    private val getEventsPagerUseCase: GetEventsPagerUseCase,
+    private val getEventsByLocationPagerUseCase: GetEventsByLocationPagerUseCase
 ) : ViewModel() {
-    private val _events = MutableStateFlow<List<Event>>(emptyList())
-    val events: StateFlow<List<Event>> = _events.asStateFlow()
+    private val locationFlow = MutableStateFlow<Int?>(null)
 
-    init {
-        getEvents()
-    }
-
-    private fun getEvents() {
-        viewModelScope.launch {
-            try {
-                _events.value = getEventsUseCase(10).events
-            } catch (e: Exception) {
-                Log.i("Parse Events", e.message.toString())
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val _eventsPager: Flow<PagingData<Event>> = locationFlow
+        .flatMapLatest { locationId ->
+            if (locationId == null) {
+                getEventsPagerUseCase.invoke(pageSize = 100)
+            } else {
+                getEventsByLocationPagerUseCase.invoke(locationId, pageSize = 100)
             }
         }
-    }
+        .cachedIn(viewModelScope)
 
-    fun getEventsByLocation(id: Int) {
-        viewModelScope.launch {
-            try {
-                _events.value = getEventsByLocationUseCase(id).events
-            } catch (e: Exception) {
-                Log.i("Parse Events", e.message.toString())
-            }
-        }
+    val eventsPager: Flow<PagingData<Event>> = _eventsPager
+
+    fun setLocationFilter(id: Int) {
+        locationFlow.value = id
     }
 
     fun resetLocationFilter() {
-        getEvents()
+        locationFlow.value = null
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,8 +14,13 @@ okhttp = "4.12.0"
 hilt = "2.51.1"
 hiltNavigationCompose = "1.2.0"
 coilCompose = "3.2.0"
+pagingRuntime = "3.3.6"
 
 [libraries]
+#Paging
+androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "pagingRuntime" }
+androidx-paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "pagingRuntime" }
+
 #Navigation
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 


### PR DESCRIPTION
This commit introduces Paging 3 to efficiently load and display events in a paginated manner.

Key changes include:

- **`EventsPagingSource`**: New PagingSource implementation to fetch events from the API. It handles loading data for both all events and events filtered by location.
- **Repository Updates**:
    - `EventsRepository` interface and `EventsRepositoryImpl` now include `getEventsPager` and `getEventsByLocationPager` methods, returning `Flow<PagingData<Event>>`.
- **Use Cases**:
    - `GetEventsPagerUseCase` and `GetEventsByLocationPagerUseCase` created to encapsulate the logic of fetching paginated events.
- **ViewModel (`HomeScreenViewModel`)**:
    - Replaced `StateFlow<List<Event>>` with `Flow<PagingData<Event>>` for `eventsPager`.
    - Implemented `locationFlow` (MutableStateFlow) to trigger re-fetching of paged data when the location filter changes.
    - Utilizes `flatMapLatest` to switch between fetching all events or location-specific events based on `locationFlow`.
    - Uses `cachedIn(viewModelScope)` to cache paged data.
- **UI (`HomeScreen`, `HomeContent`)**:
    - Adapted to use `LazyPagingItems` collected from `viewModel.eventsPager`.
    - `HomeContent` now handles loading and error states for paging (initial load and append).
- **API & DTOs**:
    - `EventsFindApi`: Added `offset` parameter to `getEvents` and `getEventsByLocation` for pagination.
    - `EventsResponseDto`: Added `AttributesDto` to include the total `count` of events, necessary for pagination logic.
    - `EventMapper`: Updated to include the `count` in the domain model.
- **Retrofit**: Increased connect and read timeouts to 60 seconds.
- **Dependencies**: Added `androidx-paging-runtime` and `androidx-paging-compose` to `build.gradle.kts` and `libs.versions.toml`.